### PR TITLE
[codex] Add Python CI

### DIFF
--- a/.github/workflows/actions-security.yml
+++ b/.github/workflows/actions-security.yml
@@ -1,0 +1,35 @@
+name: GitHub Actions Security
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  actions-security:
+    name: Check workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install aqua tools
+        uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
+        with:
+          aqua_version: v2.60.1
+
+      - name: Check action pinning
+        run: pinact run --check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Audit workflows
+        run: zizmor --format github .
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  python:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Detect Python version
+        id: python
+        shell: bash
+        run: |
+          if [[ -f .python-version ]]; then
+            python_version="$(tr -d '[:space:]' < .python-version)"
+          else
+            python_version="3.13"
+          fi
+
+          echo "version=${python_version}" >> "${GITHUB_OUTPUT}"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ steps.python.outputs.version }}
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - run: uv sync --frozen
+
+      - run: uv run --frozen python -m compileall main.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Detect Python version
-        id: python
-        shell: bash
-        run: |
-          if [[ -f .python-version ]]; then
-            python_version="$(tr -d '[:space:]' < .python-version)"
-          else
-            python_version="3.13"
-          fi
-
-          echo "version=${python_version}" >> "${GITHUB_OUTPUT}"
-
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: ${{ steps.python.outputs.version }}
+          python-version-file: .python-version
 
       - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -30,11 +30,11 @@ jobs:
 
           echo "version=${python_version}" >> "${GITHUB_OUTPUT}"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ steps.python.outputs.version }}
 
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
         with:
           enable-cache: true
 

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+  - type: standard
+    ref: v4.526.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: suzuki-shunsuke/pinact@v4.1.0
+  - name: zizmorcore/zizmor@v1.26.1


### PR DESCRIPTION
## Summary

- Add a minimal Python CI workflow for pull requests and pushes to main.
- Install dependencies with uv using the existing lockfile.
- Compile `main.py` so Python runtime updates get a non-stability check.

## Validation

- `UV_CACHE_DIR=/private/tmp/codex-uv-cache uv sync --frozen`
- `UV_CACHE_DIR=/private/tmp/codex-uv-cache uv run --frozen python -m compileall main.py`

## Notes

This supports judging Renovate PR #3 without editing the Renovate branch or PR metadata.
